### PR TITLE
Set --warn-undefined-variables to MAKEFLAGS

### DIFF
--- a/Makefile.terraform
+++ b/Makefile.terraform
@@ -7,6 +7,9 @@
 # https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html
 SHELL := /bin/bash
 
+# This option causes make to display a warning whenever an undefined variable is expanded.
+MAKEFLAGS += --warn-undefined-variables
+
 .DEFAULT_GOAL := help
 
 # https://gist.github.com/tadashi-aikawa/da73d277a3c1ec6767ed48d1335900f3


### PR DESCRIPTION
Because, this option causes make to display a warning whenever an undefined variable is expanded.