### PR TITLE
Add AWS_DEFAULT_REGION to env

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   TERRAFORM_VERSION: 0.12.24
+  AWS_DEFAULT_REGION: us-east-1
 
 jobs:
   format:


### PR DESCRIPTION
Becuase if AWS_DEFAULT_REGION is not set, the terraform validate will fail on the root module.

Error message at GitHub Actions.

```
validate: info: validating Terraform configuration in .
validate: error: failed to validate Terraform configuration in .

Error: Missing required argument

The argument "region" is required, but was not set.


validate: info: creating JSON
validate: info: commenting on the pull request
```