### PR TITLE
Suppress warn undefined variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,21 +9,21 @@ MINIMAL_DIR := ./examples/minimal
 COMPLETE_DIR := ./examples/complete
 
 plan-minimal: ## Run terraform plan examples/minimal
-	$(call terraform,${MINIMAL_DIR},init)
-	$(call terraform,${MINIMAL_DIR},plan)
+	$(call terraform,${MINIMAL_DIR},init,)
+	$(call terraform,${MINIMAL_DIR},plan,)
 
 apply-minimal: ## Run terraform apply examples/minimal
-	$(call terraform,${MINIMAL_DIR},apply)
+	$(call terraform,${MINIMAL_DIR},apply,)
 
 destroy-minimal: ## Run terraform destroy examples/minimal
-	$(call terraform,${MINIMAL_DIR},destroy)
+	$(call terraform,${MINIMAL_DIR},destroy,)
 
 plan-complete: ## Run terraform plan examples/complete
-	$(call terraform,${COMPLETE_DIR},init)
-	$(call terraform,${COMPLETE_DIR},plan)
+	$(call terraform,${COMPLETE_DIR},init,)
+	$(call terraform,${COMPLETE_DIR},plan,)
 
 apply-complete: ## Run terraform apply examples/complete
-	$(call terraform,${COMPLETE_DIR},apply)
+	$(call terraform,${COMPLETE_DIR},apply,)
 
 destroy-complete: ## Run terraform destroy examples/complete
-	$(call terraform,${COMPLETE_DIR},destroy)
+	$(call terraform,${COMPLETE_DIR},destroy,)

--- a/Makefile.terraform
+++ b/Makefile.terraform
@@ -98,11 +98,11 @@ lint-terraform:
 validate-terraform: validate-terraform-module validate-terraform-examples
 
 validate-terraform-module:
-	$(call terraform,.,init) && $(call terraform,.,validate)
+	$(call terraform,.,init,) && $(call terraform,.,validate,)
 
 validate-terraform-examples:
 	@for dir in ${EXAMPLE_DIRS}; do \
-		$(call terraform,$${dir},init) && $(call terraform,$${dir},validate); \
+		$(call terraform,$${dir},init,) && $(call terraform,$${dir},validate,); \
 	done
 
 lint-shellscript:


### PR DESCRIPTION
Warning message

```shell
$ make plan-minimal
Makefile:12: warning: undefined variable `3'
Makefile:12: warning: undefined variable `3'
```